### PR TITLE
Feat/miscellaneous updates

### DIFF
--- a/interop-test-storage-and-retrieval-local-dev-net.sh
+++ b/interop-test-storage-and-retrieval-local-dev-net.sh
@@ -436,5 +436,5 @@ tmux send-keys -t "${tmux_session}:${tmux_window_go_filecoin_client_cli}" "${go_
 
 # select a window and view your handywork
 #
-tmux select-window -t "${tmux_session}:${tmux_window_lotus_client_cli}"
+tmux select-window -t "${tmux_session}:${tmux_window_go_filecoin_client_cli}"
 tmux attach-session -t "${tmux_session}"


### PR DESCRIPTION
## What's in this PR?

1. Blasting a large number of commands with `tmux send-keys` can result in interleaved commands. To work around this, I've put all the CLI commands into their own Bash scripts.
2. The genesis miner's balance was changed to a number which was smaller than what was needed for these tests. I've updated that.
3. I've added drand network-controlling variables and such.

## Warnings

1. The go-filecoin nodes stay synchronized only for a little bit of time, and only with the go-filecoin PoSt-verification code disabled. To see what's required to disable PoSt verification in go-filecoin, either reach out to @ZenGround0 or see the `laser/sync` branch in go-filecoin.